### PR TITLE
Fix incomplete role cs

### DIFF
--- a/app/controllers/group.controller.js
+++ b/app/controllers/group.controller.js
@@ -2,7 +2,6 @@ const db = require("../models");
 const Group = db.group;
 const Role = db.role;
 const PersonRole = db.personrole;
-const Person = db.person;
 const Topic = db.topic;
 const PersonTopic = db.persontopic;
 const Op = db.Sequelize.Op;
@@ -91,6 +90,7 @@ exports.findAllForPerson = (req, res) => {
         required: true,
       },
     ],
+    order: [["name", "ASC"]],
   })
     .then((data) => {
       res.send(data);
@@ -125,6 +125,7 @@ exports.findContractsNeededForPerson = (req, res) => {
         ],
       },
     ],
+    order: [["name", "ASC"]],
   })
     .then((data) => {
       res.send(data);
@@ -170,6 +171,7 @@ exports.findTopicsNeededForTutor = (req, res) => {
         required: true,
       },
     ],
+    order: [["name", "ASC"]],
   })
     .then((data) => {
       res.send(data);

--- a/app/controllers/group.controller.js
+++ b/app/controllers/group.controller.js
@@ -2,6 +2,7 @@ const db = require("../models");
 const Group = db.group;
 const Role = db.role;
 const PersonRole = db.personrole;
+const Person = db.person;
 const Topic = db.topic;
 const PersonTopic = db.persontopic;
 const Op = db.Sequelize.Op;
@@ -102,13 +103,15 @@ exports.findAllForPerson = (req, res) => {
 };
 
 // Retrieve all Groups for a person from the database.
-exports.findAllIncompleteForPerson = (req, res) => {
+exports.findContractsNeededForPerson = (req, res) => {
   const id = req.params.personId;
 
   Group.findAll({
     include: [
       {
         model: Role,
+        as: "role",
+        required: true,
         include: [
           {
             where: {
@@ -120,8 +123,6 @@ exports.findAllIncompleteForPerson = (req, res) => {
             required: true,
           },
         ],
-        as: "role",
-        required: true,
       },
     ],
   })
@@ -136,7 +137,7 @@ exports.findAllIncompleteForPerson = (req, res) => {
 };
 
 // Retrieve all Groups and topics for a person from the database.
-exports.findAllTopicsForTutor = (req, res) => {
+exports.findTopicsNeededForTutor = (req, res) => {
   const id = req.params.personId;
 
   Group.findAll({

--- a/app/routes/group.routes.js
+++ b/app/routes/group.routes.js
@@ -21,13 +21,17 @@ module.exports = (app) => {
 
   // Retrieve all incomplete Groups for a person
   router.get(
-    "/personIn/:personId",
+    "/personNeedContracts/:personId",
     [authenticate],
-    group.findAllIncompleteForPerson
+    group.findContractsNeededForPerson
   );
 
   // Retrieve all Groups and topics for a person
-  router.get("/personT/:personId", [authenticate], group.findAllTopicsForTutor);
+  router.get(
+    "/personNeedTopics/:personId",
+    [authenticate],
+    group.findTopicsNeededForTutor
+  );
 
   // Retrieve a single Group with id
   router.get("/:id", [authenticate], group.findOne);


### PR DESCRIPTION
I fixed a couple of functions in the group controller to make sure that the correct "incomplete" roles are found for missing contracts and missing topics. I also made sure that when roles are found through the group controller, they are sent back to the front end in ascending order by name (alphabetical order).